### PR TITLE
Support aliased model classes in sqla parser

### DIFF
--- a/tests/parsers/test_sqla.py
+++ b/tests/parsers/test_sqla.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 import pytest
 from boolean_parser.parsers import SQLAParser
 from tests.models import ModelA, ModelB
-from sqlalchemy.sql.expression import BinaryExpression
+from sqlalchemy.sql.expression import BinaryExpression, BooleanClauseList
 from sqlalchemy.orm import aliased
 
 
@@ -35,13 +35,14 @@ def test_parse_filter():
     assert isinstance(f, BinaryExpression)
     assert d == ww
 
+
 def test_parse_filter_with_alias():
     ''' test a sqlalchemy filter parse with an aliased class '''
-    d = 'modela2.x > 5'
+    d = 'modela.x > 5 AND modela2.x < 3'
     f = _make_filter(d)
     ww = str(f.compile(compile_kwargs={'literal_binds': True}))
     assert f is not None
-    assert isinstance(f, BinaryExpression)
+    assert isinstance(f, BooleanClauseList)
     assert d == ww
 
 

--- a/tests/parsers/test_sqla.py
+++ b/tests/parsers/test_sqla.py
@@ -38,6 +38,15 @@ def test_parse_filter():
 
 def test_parse_filter_with_alias():
     ''' test a sqlalchemy filter parse with an aliased class '''
+    d = 'modela2.x < 3'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert d == ww
+
+def test_parse_filter_with_model_and_alias():
+    ''' test a sqlalchemy filter parse with model and aliased classes '''
     d = 'modela.x > 5 AND modela2.x < 3'
     f = _make_filter(d)
     ww = str(f.compile(compile_kwargs={'literal_binds': True}))

--- a/tests/parsers/test_sqla.py
+++ b/tests/parsers/test_sqla.py
@@ -16,17 +16,28 @@ import pytest
 from boolean_parser.parsers import SQLAParser
 from tests.models import ModelA, ModelB
 from sqlalchemy.sql.expression import BinaryExpression
+from sqlalchemy.orm import aliased
 
 
 def _make_filter(value):
+    ModelA2 = aliased(ModelA, name="modela2")
     e = SQLAParser(value).parse()
-    f = e.filter([ModelA, ModelB])
+    f = e.filter([ModelA, ModelB, ModelA2])
     return f
 
 
 def test_parse_filter():
     ''' test a sqlalchemy filter parse '''
     d = 'modela.x > 5'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert d == ww
+
+def test_parse_filter_with_alias():
+    ''' test a sqlalchemy filter parse with an aliased class '''
+    d = 'modela2.x > 5'
     f = _make_filter(d)
     ww = str(f.compile(compile_kwargs={'literal_binds': True}))
     assert f is not None


### PR DESCRIPTION
I have a query I want to use boolean_parser for that joins to a table multiple times using aliases. For example:

```
from sqlalchemy.orm import aliased

Front = aliased(Tire, name="front")
Rear = aliased(Tire, name="rear")

db.query(Bike)
    .join(Bike.front.of_type(Front))
    .join(Bike.rear.of_type(Rear))
    .filter(parse("front.size=18 and rear.size=16").filter([Bike, Front, Rear]))
```

With this PR, sqla will support aliased classes which also provide a name.