### PR TITLE
Bumps sqlalchemy to 1.4

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -3,11 +3,7 @@
 
 name: Python application
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -5,11 +5,7 @@ name: Build Sphinx Documentation
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 Change Log
 ==========
 
+[0.1.2] - 2021-06-25
+--------------------
+- Fixes :issue:`3` - bumps ``sqlalchemy`` version to >1.4
+
 [0.1.1] - 2020-11-13
 --------------------
 - Adds support (:pr:`1`) for aliased SQLAlchemy models

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Change Log
 [0.1.2] - 2021-06-25
 --------------------
 - Fixes :issue:`3` - bumps ``sqlalchemy`` version to >1.4
+- Clarifying docs on toy examples
 
 [0.1.1] - 2020-11-13
 --------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Change Log
 [0.1.2] - 2021-06-25
 --------------------
 - Fixes :issue:`3` - bumps ``sqlalchemy`` version to >1.4
-- Clarifying docs on toy examples
+- Fixes :issue:`2` - clarifying docs on toy examples
 
 [0.1.1] - 2020-11-13
 --------------------

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -15,7 +15,7 @@ from __future__ import print_function, division, absolute_import
 import inspect
 import decimal
 from sqlalchemy import func, bindparam
-from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import sqltypes, between
@@ -24,7 +24,6 @@ from boolean_parser.parsers.base import BooleanParserException
 
 
 opdict = {'<=': le, '>=': ge, '>': gt, '<': lt, '!=': ne, '==': eq, '=': eq}
-
 
 class SQLAMixin(object):
     ''' A Mixin class to apply SQLAlchemy filter parsing

--- a/docs/sphinx/intro.rst
+++ b/docs/sphinx/intro.rst
@@ -156,6 +156,12 @@ The `.SQLAParser` class for SQLAlchemy provides an additional ``filter`` functio
 string into a SQLAlchemy filter condition useable in SQLAlchemy queries.  Otherwise it behaves exactly the same as the core
 `.Parser`.
 
+..  note::
+
+    The following is a toy example.  All references to module "database.models", "datamodel.session", and 
+    class "TableModel", etc are to be replaced by your own code containing your database code and 
+    SQLAlchemy models and connections.  These are not importable in the ``boolean_parser`` package.  
+
 Suppose we have a database with a table "table" and columns "x", and "y".  The SQLAlchemy database session is
 defined in a `database` module, along with our SQLAlchemy ORM models, including a "TableModel", defined in a
 `database.models` module.  We want to parse the string expression "table.x > 5 and table.y < 2" and use it as

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python_requires = >=3.6
 packages = find:
 install_requires =
 	pyparsing>=2.4
-	sqlalchemy>=1.3.6
+	sqlalchemy>=1.4.0
 
 [options.package_data]
 boolean_parser =


### PR DESCRIPTION
Closes #2 and #3.   Updates code to support `sqlalchemy`  1.4.  Adds some clarification to the docs on the toy example for `sqlalchemy`.