### PR TITLE
Fix `bindname` errors and allow comparing against NULL values

### DIFF
--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -172,7 +172,15 @@ class SQLAMixin(object):
                 field = getattr(model, self.name)
                 value = self.value
                 if value.lower() == 'null':
-                    condition = field.is_(None)
+                    condition = field.isnot(None)
+            elif isinstance(field.type, sqltypes.DATE) or \
+                isinstance(field.type, sqltypes.DATETIME) or \
+                isinstance(field.type, sqltypes.Date) or \
+                isinstance(field.type, sqltypes.DateTime):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.isnot(None)
             else:
                 condition = lower_field.__ne__(lower_value)
         elif self.operator == '=':
@@ -192,6 +200,14 @@ class SQLAMixin(object):
                     condition = field.ilike(value)
                 else:
                     condition = field.ilike('%' + value + '%')
+            elif isinstance(field.type, sqltypes.DATE) or \
+                isinstance(field.type, sqltypes.DATETIME) or \
+                isinstance(field.type, sqltypes.Date) or \
+                isinstance(field.type, sqltypes.DateTime):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.is_(None)
             else:
                 # if not a text column, then use "=" as a straight equals
                 condition = lower_field.__eq__(lower_value)

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -285,9 +285,11 @@ class SQLAMixin(object):
         '''
 
         assert datatype in [float, int], 'datatype must be either float or int'
-
         try:
-            out = datatype(value)
+            if value.lower() == 'null':
+                out = 'null'
+            else:
+                out = datatype(value)
         except (ValueError, SyntaxError):
             raise BooleanParserException(f'Field {self.name} expects a {datatype.__name__} value.  Received {value} instead.')
         else:

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -173,6 +173,12 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.isnot(None)
+            elif isinstance(field.type, sqltypes.BOOLEAN) or \
+                isinstance(field.type, sqltypes.Boolean):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.isnot(None)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \
@@ -200,6 +206,12 @@ class SQLAMixin(object):
                     condition = field.ilike(value)
                 else:
                     condition = field.ilike('%' + value + '%')
+            elif isinstance(field.type, sqltypes.BOOLEAN) or \
+                isinstance(field.type, sqltypes.Boolean):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.isnot(None)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -163,12 +163,16 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.is_(None)
+                else:
+                    condition = lower_field.__eq__(lower_value)
             elif isinstance(field.type, sqltypes.BOOLEAN) or \
                 isinstance(field.type, sqltypes.Boolean):
                 field = getattr(model, self.name)
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.is_(None)
+                else:
+                    condition = lower_field.__eq__(lower_value)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \
@@ -177,6 +181,8 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.is_(None)
+                else:
+                    condition = lower_field.__eq__(lower_value)
             else:
                 condition = lower_field.__eq__(lower_value)
         elif self.operator == '<':
@@ -195,12 +201,16 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.isnot(None)
+                else:
+                    condition = lower_field.__ne__(lower_value)
             elif isinstance(field.type, sqltypes.BOOLEAN) or \
                 isinstance(field.type, sqltypes.Boolean):
                 field = getattr(model, self.name)
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.isnot(None)
+                else:
+                    condition = lower_field.__ne__(lower_value)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \
@@ -209,6 +219,8 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.isnot(None)
+                else:
+                    condition = lower_field.__ne__(lower_value)
             else:
                 condition = lower_field.__ne__(lower_value)
         elif self.operator == '=':
@@ -234,6 +246,8 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.is_(None)
+                else:
+                    condition = lower_field.__eq__(lower_value)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \
@@ -242,6 +256,8 @@ class SQLAMixin(object):
                 value = self.value
                 if value.lower() == 'null':
                     condition = field.is_(None)
+                else:
+                    condition = lower_field.__eq__(lower_value)
             else:
                 # if not a text column, then use "=" as a straight equals
                 condition = lower_field.__eq__(lower_value)

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -166,7 +166,15 @@ class SQLAMixin(object):
         elif self.operator == '>=':
             condition = lower_field.__ge__(lower_value)
         elif self.operator == '!=':
-            condition = lower_field.__ne__(lower_value)
+            if isinstance(field.type, sqltypes.TEXT) or \
+                isinstance(field.type, sqltypes.VARCHAR) or \
+                isinstance(field.type, sqltypes.String):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.is_(None)
+            else:
+                condition = lower_field.__ne__(lower_value)
         elif self.operator == '=':
             if isinstance(field.type, sqltypes.TEXT) or \
                 isinstance(field.type, sqltypes.VARCHAR) or \
@@ -177,7 +185,9 @@ class SQLAMixin(object):
                 # x=*5 -> x LIKE '%5' (x ends with 5)
                 field = getattr(model, self.name)
                 value = self.value
-                if value.find('*') >= 0:
+                if value.lower() == 'null':
+                    condition = field.is_(None)
+                elif value.find('*') >= 0:
                     value = value.replace('*', '%')
                     condition = field.ilike(value)
                 else:

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -179,11 +179,9 @@ class SQLAMixin(object):
                 value = self.value
                 if value.find('*') >= 0:
                     value = value.replace('*', '%')
-                    condition = field.ilike(
-                        bindparam(self.bindname, value))
+                    condition = field.ilike(value)
                 else:
-                    condition = field.ilike(
-                        '%' + bindparam(self.bindname, value) + '%')
+                    condition = field.ilike('%' + value + '%')
             else:
                 # if not a text column, then use "=" as a straight equals
                 condition = lower_field.__eq__(lower_value)

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -211,7 +211,7 @@ class SQLAMixin(object):
                 field = getattr(model, self.name)
                 value = self.value
                 if value.lower() == 'null':
-                    condition = field.isnot(None)
+                    condition = field.is_(None)
             elif isinstance(field.type, sqltypes.DATE) or \
                 isinstance(field.type, sqltypes.DATETIME) or \
                 isinstance(field.type, sqltypes.Date) or \

--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -156,7 +156,29 @@ class SQLAMixin(object):
         # Return SQLAlchemy condition based on operator value
         # self.name is parameter name, lower_field is Table.parameterName
         if self.operator == '==':
-            condition = lower_field.__eq__(lower_value)
+            if isinstance(field.type, sqltypes.TEXT) or \
+                isinstance(field.type, sqltypes.VARCHAR) or \
+                isinstance(field.type, sqltypes.String):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.is_(None)
+            elif isinstance(field.type, sqltypes.BOOLEAN) or \
+                isinstance(field.type, sqltypes.Boolean):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.is_(None)
+            elif isinstance(field.type, sqltypes.DATE) or \
+                isinstance(field.type, sqltypes.DATETIME) or \
+                isinstance(field.type, sqltypes.Date) or \
+                isinstance(field.type, sqltypes.DateTime):
+                field = getattr(model, self.name)
+                value = self.value
+                if value.lower() == 'null':
+                    condition = field.is_(None)
+            else:
+                condition = lower_field.__eq__(lower_value)
         elif self.operator == '<':
             condition = lower_field.__lt__(lower_value)
         elif self.operator == '<=':

--- a/tests/models.py
+++ b/tests/models.py
@@ -13,17 +13,20 @@
 
 from __future__ import print_function, division, absolute_import
 
-from sqlalchemy import Column, String, BigInteger, Integer, Float
+from sqlalchemy import Column, Date, String, BigInteger, Integer, Float
 from .database import Base, engine, Session
 import factory
 import factory.fuzzy
 from pytest_factoryboy import register
 
+import datetime
 
 class ModelA(Base):
     __tablename__ = 'modela'
     pk = Column(BigInteger, primary_key=True)
     name = Column(String, nullable=False)
+    nulls = Column(Integer, nullable=True)
+    dates = Column(Date, nullable=False)
     x = Column(Integer, nullable=False)
     y = Column(Integer, nullable=False)
 
@@ -49,6 +52,12 @@ class ModelAFactory(factory.alchemy.SQLAlchemyModelFactory):
     x = factory.Faker('pyint', min_value=0, max_value=20)
     y = factory.Faker('pyint', min_value=0, max_value=20)
     name = factory.fuzzy.FuzzyText(prefix='model', length=3)
+    nulls = factory.Sequence(lambda n: None)
+    dates = factory.Faker(
+        'date_between_dates',
+        date_start=datetime.date(2000, 1, 1),
+        date_end=datetime.date(2020, 1, 1),
+    )
 
 
 @register

--- a/tests/parsers/test_sqla.py
+++ b/tests/parsers/test_sqla.py
@@ -26,7 +26,7 @@ def _make_filter(value):
     return f
 
 
-def test_parse_filter():
+def test_parse_filter_gt_int():
     ''' test a sqlalchemy filter parse '''
     d = 'modela.x > 5'
     f = _make_filter(d)
@@ -34,6 +34,141 @@ def test_parse_filter():
     assert f is not None
     assert isinstance(f, BinaryExpression)
     assert d == ww
+
+
+def test_parse_filter_lt_int():
+    ''' test a sqlalchemy filter parse '''
+    d = 'modela.x < 5'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert d == ww
+
+
+def test_parse_filter_eq_int():
+    ''' test a sqlalchemy filter parse '''
+    d = 'modela.x = 5'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert d == ww
+
+
+def test_parse_filter_straight_eq_int():
+    ''' test a sqlalchemy filter parse '''
+    d_straight_eq = 'modela.x == 5'
+    f_straight_eq = _make_filter(d_straight_eq)
+    ww_straight_equals = str(f_straight_eq.compile(compile_kwargs={'literal_binds': True}))
+
+    d_eq = 'modela.x = 5'
+    f_eq = _make_filter(d_eq)
+    ww_equals = str(f_eq.compile(compile_kwargs={'literal_binds': True}))
+
+    assert f_eq is not None
+    assert f_straight_eq is not None
+    assert isinstance(f_eq, BinaryExpression)
+    assert isinstance(f_straight_eq, BinaryExpression)
+
+    # in the case of int, they should evaluate to the same expression
+    assert ww_equals == ww_straight_equals
+
+
+def test_parse_filter_eq_str():
+    ''' test a sqlalchemy filter parse '''
+    d = 'modela.name = Some_string'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert ww == "lower(lower(modela.name)) LIKE lower('%' || 'Some_string' || '%')"
+
+
+def test_parse_filter_straight_eq_str():
+    ''' test a sqlalchemy filter parse '''
+    d_straight_eq = 'modela.name == "Some_string"'
+    f_straight_eq = _make_filter(d_straight_eq)
+    ww_straight_equals = str(f_straight_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    d_eq = 'modela.name = "Some_string"'
+    f_eq = _make_filter(d_eq)
+    ww_equals = str(f_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    assert f_eq is not None
+    assert f_straight_eq is not None
+    assert isinstance(f_eq, BinaryExpression)
+    assert isinstance(f_straight_eq, BinaryExpression)
+
+    # in the case of str, they should evaluate to something different
+    assert ww_equals == "lower(lower(modela.name)) LIKE lower('%' || 'Some_string' || '%')"
+    assert ww_straight_equals == "lower(modela.name) = lower('Some_string')"
+
+
+def test_parse_filter_eq_null():
+    ''' test a sqlalchemy filter parse '''
+    d = 'modela.name = null'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert ww == "modela.name IS NULL"
+
+
+def test_parse_filter_straight_eq_null():
+    ''' test a sqlalchemy filter parse '''
+    d_straight_eq = 'modela.name == null'
+    f_straight_eq = _make_filter(d_straight_eq)
+    ww_straight_equals = str(f_straight_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    d_eq = 'modela.name = null'
+    f_eq = _make_filter(d_eq)
+    ww_equals = str(f_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    assert f_eq is not None
+    assert f_straight_eq is not None
+    assert isinstance(f_eq, BinaryExpression)
+    assert isinstance(f_straight_eq, BinaryExpression)
+
+    # in the case of str, they should evaluate to something different
+    assert ww_equals == "modela.name IS NULL"
+    assert ww_equals == ww_straight_equals
+
+
+def test_parse_filter_eq_date():
+    ''' test a sqlalchemy filter parse '''
+    d = 'modela.dates = 2020-01-01'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    assert f is not None
+    assert isinstance(f, BinaryExpression)
+    assert ww == "lower(modela.dates) = lower('2020-01-01')"
+
+
+def test_parse_filter_straight_eq_date():
+    ''' test a sqlalchemy filter parse '''
+    d_straight_eq = 'modela.dates == 2020-01-01'
+    f_straight_eq = _make_filter(d_straight_eq)
+    ww_straight_equals = str(f_straight_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    d_eq = 'modela.dates = 2020-01-01'
+    f_eq = _make_filter(d_eq)
+    ww_equals = str(f_eq.compile(
+        compile_kwargs={'literal_binds': True}))
+
+    assert f_eq is not None
+    assert f_straight_eq is not None
+    assert isinstance(f_eq, BinaryExpression)
+    assert isinstance(f_straight_eq, BinaryExpression)
+
+    # in the case of str, they should evaluate to something different
+    assert ww_equals == "lower(modela.dates) = lower('2020-01-01')"
+    assert ww_equals == ww_straight_equals
 
 
 @pytest.mark.parametrize('query, kls',
@@ -61,9 +196,37 @@ def test_query(session):
     assert len(res) > 0 and len(res) < 20
 
 
-def test_query_with_filter(session):
+def test_query_with_filter_gt_date(session):
     ''' test a query with a parsed filter '''
-    d = 'modela.x > 5'
+    d = 'modela.dates > 2020-01-01'
     f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
     res = session.query(ModelA).filter(f).all()
-    assert len(res) > 0 and len(res) < 20
+    assert len(res) == 0
+
+
+def test_query_with_filter_lt_date(session):
+    ''' test a query with a parsed filter '''
+    d = 'modela.dates < 2020-01-01'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    res = session.query(ModelA).filter(f).all()
+    assert len(res) == 20
+
+
+def test_query_with_filter_eq_null(session):
+    ''' test a query with a parsed filter '''
+    d = 'modela.nulls == NULL'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    res = session.query(ModelA).filter(f).all()
+    assert len(res) == 20
+
+
+def test_query_with_filter_nq_null(session):
+    ''' test a query with a parsed filter '''
+    d = 'modela.nulls != Null'
+    f = _make_filter(d)
+    ww = str(f.compile(compile_kwargs={'literal_binds': True}))
+    res = session.query(ModelA).filter(f).all()
+    assert len(res) == 0


### PR DESCRIPTION
This fixes #5 and adds the ability to compare against `NULL` in the queries which is something that we need over here: https://git.fsfe.org/fsfe-system-hackers/fsfe-cd/pulls/163.

Many thanks for this great parser. I'm looking forward to including a version of it in the aforementioned project.