### PR TITLE
Don't use `bindparam` when comparing strings with `=`

### DIFF
--- a/boolean_parser/mixins/sqla.py
+++ b/boolean_parser/mixins/sqla.py
@@ -199,9 +199,9 @@ class SQLAMixin(object):
                 # x=*5  ->  x LIKE '%5'  (x ends with 5)
                 elif value.find('*') >= 0:
                     value = value.replace('*', '%')
-                    condition = lower_field.ilike(bindparam(self.fullname, value))
+                    condition = lower_field.ilike(value)
                 else:
-                    condition = lower_field.ilike('%' + bindparam(self.fullname, value) + '%')
+                    condition = lower_field.ilike('%' + value + '%')
             # For all other types, assume straight equality
             else:
                 field = getattr(model, self.name)

--- a/tests/parsers/test_sqla.py
+++ b/tests/parsers/test_sqla.py
@@ -32,7 +32,7 @@ def _make_filter(value):
         ("modela.x < 5", "modela.x < 5"),
         ("modela.x = 5", "modela.x = 5"),
         ("modela.x == 5", "modela.x = 5"),
-        ("modela.name = Some_string", "lower(lower(modela.name)) LIKE lower('%' || 'Some_string' || '%')",),
+        ("modela.name = Some_string", "lower(lower(modela.name)) LIKE lower('%Some_string%')",),
         ('modela.name == "Some_string"', "lower(modela.name) = lower('Some_string')"),
         ("modela.name = null", "modela.name IS NULL"),
         ("modela.name == null", "modela.name IS NULL"),


### PR DESCRIPTION
This fixes the issue outlined in #11. 

I'm not fully aware of the implications of not binding the values here but have tested extensively that this fixes the problem outlined in #11. 

Another thing to consider is adding tests that would capture errors like the one mentioned in #11 in the future.